### PR TITLE
Correct collecting data for request transaction and request transaction naming

### DIFF
--- a/src/Struct/Transactions/RequestTransaction.php
+++ b/src/Struct/Transactions/RequestTransaction.php
@@ -2,8 +2,12 @@
 
 namespace Nivseb\LaraMonitor\Struct\Transactions;
 
+use Illuminate\Routing\Route;
+
 class RequestTransaction extends AbstractTransaction
 {
+    public ?Route $route = null;
+
     public string $method = '';
 
     public string $path = '';
@@ -12,6 +16,10 @@ class RequestTransaction extends AbstractTransaction
 
     public function getName(): string
     {
-        return $this->method.' '.$this->path;
+        if (!$this->route) {
+            return $this->method.' '.$this->path;
+        }
+
+        return $this->method.' /'.$this->route->uri();
     }
 }

--- a/tests/Unit/Struct/Transactions/RequestTransactionTest.php
+++ b/tests/Unit/Struct/Transactions/RequestTransactionTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Struct\Transactions;
 
 use Carbon\CarbonInterface;
+use Illuminate\Routing\Route;
 use Nivseb\LaraMonitor\Struct\Tracing\StartTrace;
 use Nivseb\LaraMonitor\Struct\Transactions\RequestTransaction;
 use Nivseb\LaraMonitor\Struct\User;
@@ -13,6 +14,19 @@ test(
         $transaction         = new RequestTransaction(new StartTrace(false, 0.00));
         $transaction->method = $method;
         $transaction->path   = $uri;
+
+        expect($transaction->getName())->toBe($expectedName);
+    }
+)
+    ->with('simple method and path combinations');
+
+test(
+    'transaction name is build from method and route for default request transaction',
+    function (string $method, string $uri, string $expectedName): void {
+        $transaction         = new RequestTransaction(new StartTrace(false, 0.00));
+        $transaction->method = $method;
+        $transaction->path   = 'ThatIsThePathNotTheRoute';
+        $transaction->route  = new Route(['GET', 'HEAD'], $uri, []);
 
         expect($transaction->getName())->toBe($expectedName);
     }


### PR DESCRIPTION
Use route definition for request transaction naming, for that collect the route from events/request. In some cases of octane the route can only resolved from the handled event