### PR TITLE
fix(collecting): stop render span at ResponsePrepared event

### DIFF
--- a/src/Collectors/SpanCollector.php
+++ b/src/Collectors/SpanCollector.php
@@ -30,10 +30,9 @@ class SpanCollector implements SpanCollectorContract
         if (!$parentTraceEvent) {
             return null;
         }
-        $span = $system ?
-            LaraMonitorMapper::buildSystemSpan($parentTraceEvent, $name, $type, $subType, $startAt)
-            :
-            LaraMonitorMapper::buildPlainSpan($parentTraceEvent, $name, $type, $subType, $startAt);
+        $span = $system
+            ? LaraMonitorMapper::buildSystemSpan($parentTraceEvent, $name, $type, $subType, $startAt)
+            : LaraMonitorMapper::buildPlainSpan($parentTraceEvent, $name, $type, $subType, $startAt);
         if (!$span) {
             return null;
         }

--- a/src/Providers/LaraMonitorEndServiceProvider.php
+++ b/src/Providers/LaraMonitorEndServiceProvider.php
@@ -15,7 +15,6 @@ use Illuminate\Http\Client\Events\ConnectionFailed;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Redis\Events\CommandExecuted;
-use Illuminate\Routing\Events\PreparingResponse;
 use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Support\Facades\Config;
 use Nivseb\LaraMonitor\Collectors\SpanCollector;

--- a/src/Providers/LaraMonitorEndServiceProvider.php
+++ b/src/Providers/LaraMonitorEndServiceProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Client\Events\ResponseReceived;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Redis\Events\CommandExecuted;
 use Illuminate\Routing\Events\PreparingResponse;
+use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Support\Facades\Config;
 use Nivseb\LaraMonitor\Collectors\SpanCollector;
 use Nivseb\LaraMonitor\Facades\LaraMonitorApm;
@@ -171,7 +172,7 @@ class LaraMonitorEndServiceProvider extends AbstractLaraMonitorServiceProvider
 
     protected function registerPrepareResponseEvents(Dispatcher $dispatcher): void
     {
-        $dispatcher->listen(PreparingResponse::class, fn () => LaraMonitorSpan::stopAction());
+        $dispatcher->listen(ResponsePrepared::class, fn () => LaraMonitorSpan::stopAction());
     }
 
     protected function registerHttpClientEvents(Dispatcher $dispatcher): void

--- a/src/Providers/LaraMonitorStartServiceProvider.php
+++ b/src/Providers/LaraMonitorStartServiceProvider.php
@@ -221,9 +221,9 @@ class LaraMonitorStartServiceProvider extends AbstractLaraMonitorServiceProvider
         $dispatcher->listen(
             ScheduledTaskStarting::class,
             function (ScheduledTaskStarting $event): void {
-                $name = $event->task instanceof CallbackEvent ?
-                    $event->task->getSummaryForDisplay() :
-                    trim(str_replace(ConsoleApplication::phpBinary(), '', $event->task->command ?? ''));
+                $name = $event->task instanceof CallbackEvent
+                    ? $event->task->getSummaryForDisplay()
+                    : trim(str_replace(ConsoleApplication::phpBinary(), '', $event->task->command ?? ''));
                 $type = $event->task->runInBackground ? 'start' : 'call';
                 LaraMonitorSpan::startAction($type.' '.$name, 'schedule', 'run', system: true);
             }

--- a/src/Struct/AbstractTraceEvent.php
+++ b/src/Struct/AbstractTraceEvent.php
@@ -23,9 +23,9 @@ abstract class AbstractTraceEvent
             '00',
             $this->getTraceId(),
             $this->getId(),
-            $this->isSampled() ?
-                sprintf('%02x', W3CTraceParent::SAMPLE_FLAG) :
-                sprintf('%02x', W3CTraceParent::NO_FLAG)
+            $this->isSampled()
+                ? sprintf('%02x', W3CTraceParent::SAMPLE_FLAG)
+                : sprintf('%02x', W3CTraceParent::NO_FLAG)
         );
     }
 }


### PR DESCRIPTION
The span for rendering actions should not stop from the same event that starts the rendering action.

closes #30 