### PR TITLE
fix(dont create trace parent header for completed trace events):

### DIFF
--- a/src/Http/TraceParentMiddleware.php
+++ b/src/Http/TraceParentMiddleware.php
@@ -12,7 +12,7 @@ class TraceParentMiddleware
     {
         return function (RequestInterface $request, array $options) use (&$handler) {
             $traceEvent = LaraMonitorStore::getCurrentTraceEvent();
-            if ($traceEvent) {
+            if ($traceEvent && !$traceEvent->isCompleted()) {
                 $request = $request->withHeader('traceparent', (string) $traceEvent->asW3CTraceParent());
             }
 


### PR DESCRIPTION
To have the correct trace parent relation, a trace parent header should only added for non completed trace events.