### PR TITLE
fix(remove php 8.1 requirement)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ Add some logs that shows the problem and the context to reproduce.
 
 **Environment (please complete the following information):**
 
-- PHP Version: [e.g. 8.1]
+- PHP Version: [e.g. 8.2]
 - Laravel Version: [e.g. 10.0]
 - Octane Version [e.g. 1.0]
 - Elastic APM Server Version [e.g. 8.0]

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "composer-runtime-api": "^2.0",
         "illuminate/contracts": "^11.0|^12.0",
         "jasny/persist-sql-query": "v3.0.0-alpha1",


### PR DESCRIPTION
Laravel 11 already  requires at least php 8.2