### PR TITLE
fix method definition in LaraMonitorError-Facade

### DIFF
--- a/src/Facades/LaraMonitorError.php
+++ b/src/Facades/LaraMonitorError.php
@@ -10,7 +10,7 @@ use Throwable;
 
 /**
  * @method static Error|null captureExceptionAsError(Throwable $exception, bool $handled = false, CarbonInterface $time = null)
- * @method static Error|null captureError(string $type, int|string $code, string $message, bool $handled = false, ?CarbonInterface $time = null, ?Throwable $exception = null)
+ * @method static Error|null captureError(string $type, int|string $code, string $message, bool $handled = false, ?CarbonInterface $time = null, array $additionalData = [], ?Throwable $exception = null)
  *
  * @see ErrorCollectorContract
  */


### PR DESCRIPTION
when I try to use the additionalData-Param on ErrorCollectorContract::captureError() / ErrorCollector::captureError() via LaraMonitorError-Facade, phpstan blocks it because it looks into the method-definition on the facade where this parameter is missing